### PR TITLE
Silence output of install-tpl.sh to make test results less verbose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - cd $TRAVIS_BUILD_DIR/..
   - git clone https://github.com/gsjaardema/seacas.git
   - cd seacas && export ACCESS=`pwd`
-  - GNU_PARALLEL=OFF CGNS=OFF MATIO=OFF ./install-tpl.sh
+  - GNU_PARALLEL=OFF CGNS=OFF MATIO=OFF ./install-tpl.sh &> install-tpl-output.txt
 
 install:
   # Seacas requires cmake > 3.10 (unfortunately have to compile from source)


### PR DESCRIPTION
Installing the third party libraries in seacas prints out several thousand lines of output during compilation, making the travis output difficult to read as it exceeds the 10K line limit. This change redirects the output of this script to a txt file, making the final tests visible in the travis console.