### PR TITLE
No longer run CI tests using python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
-  - "2.7"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 before_install:
   - cd $TRAVIS_BUILD_DIR/..


### PR DESCRIPTION
We don't plan to support python 2 any longer, so no need to test using it.